### PR TITLE
Adds simple README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+vimplenote-vim
+==============
+
+
+Description
+-----------
+Simplenote client for vim written in pure vimscript.
+
+Requires
+--------
+* [curl command](http://curl.haxx.se/) : http://curl.haxx.se/
+* [webapi-vim](https://github.com/mattn/webapi-vim) : https://github.com/mattn/webapi-vim	
+
+Thanks
+------
+* Daniel Schauenberg ([mrtazz](https://github.com/mrtazz))
+: [simplenote.vim](https://github.com/mrtazz/simplenote.vim)


### PR DESCRIPTION
Hi Yasuhiro. I'm adding a simple README for vimplenote that specifies that it requires your webapi-vim plugin as it wasn't obvious to me. Thanks for the plugin!
