### PR TITLE
fix email inputing during auth

### DIFF
--- a/autoload/vimplenote.vim
+++ b/autoload/vimplenote.vim
@@ -16,7 +16,7 @@ endif
 
 function! s:interface.get_email() dict
   let self.email = get(g:, 'VimpleNoteUsername', '')
-  if len(self.token) <= 0 || len(self.email) <= 0
+  if len(self.token) <= 0 && len(self.email) <= 0
     let self.email = input('email: ')
   endif
   return self.email


### PR DESCRIPTION
in `s:interface.get_email()`, the if condition should be `and` instead of `or`. or the email will be asked to input even if it is configure in `.vimrc` via `g:VimpleNoteUsername`